### PR TITLE
Add benchmark dependencies and bump CI to 4.08

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           - ubuntu-latest
           # - windows-latest
         ocaml-compiler:
-          - 4.03.x
+          - 4.08.x
           - 4.13.x
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 on:
   pull_request:
-  push:
+  push: 
+    branches: [ main ]
   schedule:
     # Prime the caches every Monday
     - cron: 0 1 * * MON

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ ocaml-geojson
 A collection of libraries for parsing, building and manipulating [geojson][] (a.k.a RFC7946). There are two libraries:
 
  - *geojson*: a library of types and functors for building useful modules for manipulating and constructing geojson. [Consult the documentation](https://geocaml.github.io/ocaml-geojson/geojson/index.html).
- - *geojsonm*: geojson can be huge (GBs of data) so building an in-memory representation of the geojson is infeasible. Geojsonm uses the excellent [jsonm]() to provide functions to manipulate geojson using a streaming parser. [Consult the documentation](https://geocaml.github.io/ocaml-geojson/geojsonm/Geojsonm/index.html)
+ - *geojsonm*: geojson can be huge (GBs of data) so building an in-memory representation of the geojson is infeasible. Geojsonm uses the excellent [jsonm](https://erratique.ch/software/jsonm/doc/Jsonm/index.html) to provide functions to manipulate geojson using a streaming parser. [Consult the documentation](https://geocaml.github.io/ocaml-geojson/geojsonm/Geojsonm/index.html)
 
 [geojson]: https://datatracker.ietf.org/doc/html/rfc7946

--- a/dune-project
+++ b/dune-project
@@ -19,6 +19,8 @@
  (description "Geojson is a 'schema' for JSON to describe geospatial information. 
   This library provides a functor for building a module for manipulating and parsing Geojson into OCaml.")
  (depends
+   (brr :with-test)
+   (bechamel-notty (and (>= 0.1.0) :with-test))
    (alcotest :with-test)
    (ezjsonm  :with-test)))
 

--- a/geojson.opam
+++ b/geojson.opam
@@ -11,6 +11,8 @@ homepage: "https://github.com/patricoferris/ocaml-geojson"
 bug-reports: "https://github.com/patricoferris/ocaml-geojson/issues"
 depends: [
   "dune" {>= "2.9"}
+  "brr" {with-test}
+  "bechamel-notty" {>= "0.1.0" & with-test}
   "alcotest" {with-test}
   "ezjsonm" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
This PR adds the benchmarking dependencies (as test deps) and bumps the CI compiler lower bound to 4.08.