### PR TITLE
Added information for installing the correct version of `ocamlformat`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ dune runtest
 
 And now you have successfully cloned and build the repository to your local!! :tada:
 
-If you are making any changes to the codes, *for instance*, you have made some kind of modifications to the files that has `.ml` extension, then please also run the formatter on the code to enhance the readability of your code and to keep your code free from programatic/ syntax and stylistic errors as well. You can achieve this by running the following command:
+After making changes to the code please also run the formatter to maintain a common style across the codebase. You can achieve this by running the following command:
 
 ```
 dune build @fmt --auto

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,6 @@ And to run the tests (which are in the `test` directory) run:
 dune runtest
 ```
 
-And now you have successfully cloned and build the repository to your local!! :tada:
 
 After making changes to the code please also run the formatter to maintain a common style across the codebase. You can achieve this by running the following command:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ And to run the tests (which are in the `test` directory) run:
 dune runtest
 ```
 
-And now you have successfully cloned and build the repository to you local!! :tada:
+And now you have successfully cloned and build the repository to your local!! :tada:
 
-If you are making any changes to the codes, for instance, you have made some kind of modifications to the files that has `.ml` extension, then please also run the formatter on the code to enhance the readability of your code and to keep your code free from programatic/ syntax and stylistic errors as well. You can achieve this by running the following command:
+If you are making any changes to the codes, *for instance*, you have made some kind of modifications to the files that has `.ml` extension, then please also run the formatter on the code to enhance the readability of your code and to keep your code free from programatic/ syntax and stylistic errors as well. You can achieve this by running the following command:
 
 ```
 dune build @fmt --auto
@@ -37,7 +37,7 @@ To run this command without any error, you might need to install the correct ver
 opam install ocamlformat=X.XX.X
 ```
 
-where, `X.XX.X` denotes the version being stated in the respective file. For instance, if `0.20.1` version of `ocamlformat` has to be installed, then you must run `opam install ocamlformat=0.20.1`. For more information kindly visit [OCamlFormat](https://github.com/ocaml-ppx/ocamlformat).
+where, `X.XX.X` denotes the version being stated in the respective file. *For example*, if `0.20.1` version of `ocamlformat` has to be installed, then you must run `opam install ocamlformat=0.20.1`. To know more, kindly visit [OCamlFormat](https://github.com/ocaml-ppx/ocamlformat).
 
 If you hit any problems please feel free to open an issue. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,23 @@ And to run the tests (which are in the `test` directory) run:
 dune runtest
 ```
 
-If you hit any problems please feel free to open an issue. Please also run the formatter on the code too with `dune build @fmt --auto`, you might need to install the correct version of `ocamlformat`.
+And now you have successfully cloned and build the repository to you local!! :tada:
+
+If you are making any changes to the codes, for instance, you have made some kind of modifications to the files that has `.ml` extension, then please also run the formatter on the code to enhance the readability of your code and to keep your code free from programatic/ syntax and stylistic errors as well. You can achieve this by running the following command:
+
+```
+dune build @fmt --auto
+```
+
+To run this command without any error, you might need to install the correct version of `ocamlformat`. For verifying which version of it has to be installed, please check out the version mentioned in the `.ocamlformat` file and install it by running:
+
+```
+opam install ocamlformat=X.XX.X
+```
+
+where, `X.XX.X` denotes the version being stated in the respective file. For instance, if `0.20.1` version of `ocamlformat` has to be installed, then you must run `opam install ocamlformat=0.20.1`. For more information kindly visit [OCamlFormat](https://github.com/ocaml-ppx/ocamlformat).
+
+If you hit any problems please feel free to open an issue. 
 
 ## Git and GitHub workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ If you are making any changes to the codes, *for instance*, you have made some k
 dune build @fmt --auto
 ```
 
-To run this command without any error, you might need to install the correct version of `ocamlformat`. For verifying which version of it has to be installed, please check out the version mentioned in the `.ocamlformat` file and install it by running:
+To run this command without any error, you might need to install the correct version of `ocamlformat`. The `.ocamlformat` file records the current version the repository uses. Install this version by running:
 
 ```
 opam install ocamlformat=X.XX.X

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ To run this command without any error, you might need to install the correct ver
 opam install ocamlformat=X.XX.X
 ```
 
-where, `X.XX.X` denotes the version being stated in the respective file. *For example*, if `0.20.1` version of `ocamlformat` has to be installed, then you must run `opam install ocamlformat=0.20.1`. To know more, kindly visit [OCamlFormat](https://github.com/ocaml-ppx/ocamlformat).
+where, `X.XX.X` denotes the version in the `.ocamlformat` file. *For example*, if the `0.20.1` version of `ocamlformat` has to be installed, then you must run `opam install ocamlformat=0.20.1`. To know more, kindly visit [OCamlFormat](https://github.com/ocaml-ppx/ocamlformat).
 
 If you hit any problems please feel free to open an issue. 
 


### PR DESCRIPTION
## Description
This is in continuation with #22. This PR describes how to install the correct version of `ocamlformat` with a bit information to help new contributors.

## Changes Incorporated
The following changes has been made to the `CONTRIBUTING.md` file:

- [x] Information has been added on how to install the correct version of `ocamlformat`
- [x] Added a Link to github page of `ocamlformat`  