### PR TITLE
Added Foreign Members

### DIFF
--- a/src/geojson/geojson_intf.ml
+++ b/src/geojson/geojson_intf.ml
@@ -183,6 +183,8 @@ module type Geometry = sig
     | Collection of t list
 
   include Json_conv with type t := t and type json := json
+
+  val foreign_members : t -> json
 end
 
 module type S = sig
@@ -198,6 +200,7 @@ module type S = sig
 
     val geometry : t -> Geometry.t option
     val properties : t -> json option
+    val foreign_members : t -> json
 
     include Json_conv with type t := t and type json := json
 
@@ -215,6 +218,8 @@ module type S = sig
       (** [v features] creates a feature collection from a list of features *)
 
       include Json_conv with type t := t and type json := json
+
+      val foreign_members : t -> json
     end
   end
 
@@ -235,6 +240,9 @@ module type S = sig
   (** [v geojson bbox] combines geojson and bbox to return a GeoJSON object (a
       type {!t}) *)
 
+  val foreign_members : t -> json
+  (** [foreign_members t] will extract foreign members from t (a GeoJSON object) *)
+
   val of_json : json -> (t, [ `Msg of string ]) result
   (** [of_json json] converts the JSON to a GeoJSON object (a type {!t}) or an
       error. *)
@@ -252,7 +260,12 @@ module type S = sig
       | MultiPolygon of int * int
       | Collection of geometry list
 
-    type feature = { properties : json option; geometry : geometry }
+    type feature = {
+      properties : json option;
+      geometry : geometry;
+      foreign_members : json;
+    }
+
     type r = FC of feature list | F of feature | G of geometry
 
     (** {3 Generate random geojson}


### PR DESCRIPTION
This PR is in continuation with #32. This PR deals with implementation of `foreign_members` according to the mentioned description in [RFC](https://datatracker.ietf.org/doc/html/rfc7946#section-6.1)