### PR TITLE
Make correction to depict the appropriate ring(interior or exterior) in Polygon's module

### DIFF
--- a/src/geojson/geojson.ml
+++ b/src/geojson/geojson.ml
@@ -167,11 +167,11 @@ module Make (J : Intf.Json) = struct
 
       let typ = "Polygon"
       let rings = Fun.id
-      let interior_ring t = t.(0)
+      let exterior_ring t = t.(0)
 
       (* If used a lot, should changed to cstruct style off and len
          to avoid the allocations here. *)
-      let exterior_rings t = Array.sub t 1 (Array.length t - 1)
+      let interior_rings t = Array.sub t 1 (Array.length t - 1)
       let v = Fun.id
 
       let parse_coords coords =

--- a/src/geojson/geojson_intf.ml
+++ b/src/geojson/geojson_intf.ml
@@ -155,7 +155,13 @@ module type Geometry = sig
     (** [rings t] returns the linear rings contained in [t] (a Polygon object) *)
 
     val exterior_ring : t -> LineString.t
+    (** [exterior_ring t] returns the first linear ring contained in [t] (a
+        Polygon object). This ring bounds the surface *)
+
     val interior_rings : t -> LineString.t array
+    (** If [t] (a Polygon object) contains more than 1 linear ring,
+        [interior_rings t] returns the rest of the linear rings apart from the
+        first. These rings (if present), bound the holes. *)
 
     val v : LineString.t array -> t
     (** Create a polygon object from an array of close line strings (note no

--- a/src/geojson/geojson_intf.ml
+++ b/src/geojson/geojson_intf.ml
@@ -154,8 +154,8 @@ module type Geometry = sig
     val rings : t -> LineString.t array
     (** [rings t] returns the linear rings contained in [t] (a Polygon object) *)
 
-    val interior_ring : t -> LineString.t
-    val exterior_rings : t -> LineString.t array
+    val exterior_ring : t -> LineString.t
+    val interior_rings : t -> LineString.t array
 
     val v : LineString.t array -> t
     (** Create a polygon object from an array of close line strings (note no


### PR DESCRIPTION
Made minor correction to the Polygon module based on [GeoJSON specification of the Polygon type](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6). An excerpt  is provided below.

>  For Polygons with more than one of these rings, the first MUST be
      the exterior ring, and any others MUST be interior rings.  The
      exterior ring bounds the surface, and the interior rings (if
      present) bound holes within the surface.