### PR TITLE
Implementing Foreign Members

### DIFF
--- a/src/geojson/geojson.ml
+++ b/src/geojson/geojson.ml
@@ -281,6 +281,7 @@ module Make (J : Intf.Json) = struct
     type t = Geometry.t option * json option
 
     let v ?properties geo = (Some geo, properties)
+    let w ?foreign_members geom = (Some geom, foreign_members)
     let geometry = fst
     let properties = snd
 
@@ -290,13 +291,16 @@ module Make (J : Intf.Json) = struct
           match J.to_string typ with
           | Ok "Feature" -> (
               match
-                (J.find json [ "geometry" ], J.find json [ "properties" ])
+                ( J.find json [ "geometry" ],
+                  J.find json [ "properties" ],
+                  J.find json [ "foreign_members" ] )
               with
-              | Some geometry, props ->
+              | Some geometry, props, forgn ->
                   Result.map
-                    (fun v -> (Option.some v, props))
-                    (Geometry.base_of_json geometry)
-              | None, props -> Ok (None, props))
+                    ((fun v -> (Option.some v, props))
+                       (Geometry.base_of_json geometry))
+                    (fun w -> (Option.some w, forgn))
+              | None, props, forgn -> Ok (None, props, forgn))
           | Ok s ->
               Error
                 (`Msg

--- a/src/geojson/geojson_intf.ml
+++ b/src/geojson/geojson_intf.ml
@@ -204,10 +204,13 @@ module type S = sig
 
     val geometry : t -> Geometry.t option
     val properties : t -> json option
+    val foreign_members : t -> (string * json) list option
 
     include Json_conv with type t := t and type json := json
 
     val v : ?properties:json -> Geometry.t -> t
+
+    val w : ?foreign_members:(string * json) list -> Geometry.t -> t
     (** [v geo] creates a new feature object, you may wish to provide a
         [properties] JSON object for the feature too. *)
 
@@ -241,6 +244,8 @@ module type S = sig
   (** [v geojson bbox] combines geojson and bbox to return a GeoJSON object (a
       type {!t}) *)
 
+  val foreign_members : t -> (string * json) list option
+
   val of_json : json -> (t, [ `Msg of string ]) result
   (** [of_json json] converts the JSON to a GeoJSON object (a type {!t}) or an
       error. *)
@@ -258,7 +263,12 @@ module type S = sig
       | MultiPolygon of int * int
       | Collection of geometry list
 
-    type feature = { properties : json option; geometry : geometry }
+    type feature = {
+      properties : json option;
+      geometry : geometry;
+      foreign_members : (string * json) list option;
+    }
+
     type r = FC of feature list | F of feature | G of geometry
 
     (** {3 Generate random geojson}

--- a/test/geojson/test.ml
+++ b/test/geojson/test.ml
@@ -430,12 +430,13 @@ let test_random () =
   let r =
     FC
       [
-        { properties = None; geometry = Point };
-        { properties = None; geometry = LineString 2 };
-        { properties = None; geometry = Polygon 2 };
+        { properties = None; geometry = Point; foreign_members = None };
+        { properties = None; geometry = LineString 2; foreign_members = None };
+        { properties = None; geometry = Polygon 2; foreign_members = None };
         {
           properties = Some (`O [ ("name", `String "abcd") ]);
           geometry = MultiPolygon (3, 3);
+          foreign_members = None;
         };
       ]
   in


### PR DESCRIPTION
This PR solves #32 . This PR deals with implementation of `foreign_members` according to the mentioned description in [RFC](https://datatracker.ietf.org/doc/html/rfc7946#section-6.1)